### PR TITLE
Lager version bump for OTP19. Workaround for 'From' header overloading

### DIFF
--- a/include/pat.hrl
+++ b/include/pat.hrl
@@ -1,4 +1,5 @@
 -record(email, {sender           :: pat:address(),
+                from             :: pat:address(),
                 recipients       :: [pat:address()],
                 subject = <<"">> :: binary(),
                 message          :: binary(),

--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,5 @@
             warn_untyped_records]}.
 
 {deps, [{gproc, "0.5.0"},
-        {lager, "3.0.2"},
+        {lager, "3.2.1"},
         {tempo, {git, "https://github.com/selectel/tempo.git", {tag, "0.4.3"}}}]}.


### PR DESCRIPTION
Lager <3.2.1 doesn't play nice with newer OTP releases.

As for the 'From' header, it doesn't seem right that it's hardcoded and a client code doesn't have access to the value. As it is now, you can't pass a name with an email for this header as 'MAIL FROM' command doesn't accept such format. It'd probably be better to incorporate full RFC-compliant address parser, but it seems like an overkill as a lib doesn't really follow those. This is a "hack" but seems to be working fine